### PR TITLE
add multi-like filter (mlike)

### DIFF
--- a/paginate.go
+++ b/paginate.go
@@ -706,6 +706,21 @@ func generateWhereCauses(f pageFilters, config Config) ([]string, []interface{})
 				} else {
 					params = append(params, f.Value)
 				}
+			case "MLIKE":
+				fname = strings.TrimSuffix(fname, "\"")
+				fname = strings.TrimPrefix(fname, "\"")
+
+				cols := strings.Split(fname, ",")
+				cs := len(cols)
+				for i, col := range cols {
+					c := fmt.Sprintf("LOWER((\"%s\")::text)", col)
+					wheres = append(wheres, c, "LIKE", "?")
+					if (cs - 1) != i {
+						wheres = append(wheres, "OR")
+					}
+					p := fmt.Sprintf("%%%s%%", strings.ToLower(valueFixer(f.Value).(string)))
+					params = append(params, p)
+				}
 			default:
 				wheres = append(wheres, fname, f.Operator, "?")
 				params = append(params, valueFixer(f.Value))


### PR DESCRIPTION
- mlike filter allows to search using like in many fields
-  example http://localhost:3000/?filters=["name,summart,title","mlike","john"]
```sql 
SELECT * FROM user WHERE name LIKE '%john%' OR summary LIKE '%john%' OR title LIKE '%john%'  LIMIT 10 OFFSET 0
```
- you can achieve same behaviour chaining many likes but the filter strings grows too much