### PR TITLE
Markdown, add gorm config queryfields note

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,11 @@ go get -u github.com/morkid/paginate
 ## Configuration
 
 ```go
+// gorm.Config.QueryFields must false for avoid error in pagination
+config := gorm.Config{
+    QueryFields: false,
+}
+
 var db *gorm.DB = ...
 var req *http.Request = ...
 // or


### PR DESCRIPTION
Set gorm.Config.QueryFields must be **false**
Because it can be causes some errors on showing data, the selector will be like this
`
SELECT "s"."id","s"."sort","s"."status","s"."created_at","s"."updated_at","s"."deleted_at","s"."creator_id","s"."modifier_id","s"."integration_partner_id","s"."payment_gateway_id","s"."merchant_id","s"."terminal_id","s"."channel_code","s"."currency_id","s"."transaction_url","s"."notification_url","s"."client_key","s"."server_key","s"."bank_id","s"."virtual_account_number","s"."convenience_store_code" FROM
`